### PR TITLE
Add a SetupTools setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='yaboli',
+        version='1.0', 
+        description='Yet Another BOt LIbrary for euphoria.io',
+        author='Garmelon',
+        url='https://github.com/Garmelon/yaboli',
+        packages=['yaboli'],
+        install_requires=['websockets']
+)


### PR DESCRIPTION
This will making installing & using yaboli easier.
One would run `setup.py install` and then yaboli would be a valiable like any other package on their system